### PR TITLE
Add namespace to packages

### DIFF
--- a/lib/moneygun/package.json
+++ b/lib/moneygun/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "moneygun",
+  "name": "@concordia-fi/moneygun",
   "version": "1.0.3",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/lib/wallet/package.json
+++ b/lib/wallet/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wallet",
+  "name": "@concordia-fi/wallet",
   "version": "1.0.1",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/lib/wallet/src/index.ts
+++ b/lib/wallet/src/index.ts
@@ -1,5 +1,11 @@
-import { AptosFunctionPayload } from 'payload'
 import { AptosClient, AptosAccount, HexString } from 'aptos'
+
+export interface EntryFunctionPayload {
+  type: 'entry_function_payload'
+  function: string
+  arguments: any[] // matching Aptos's EntryFunctionPayload
+  type_arguments: string[]
+}
 
 const path = require('path')
 export const DEFAULT_CONFIG = path.join(process.env.HOME, '.aptos', 'config.yaml')
@@ -53,7 +59,7 @@ export async function signAndSubmit({
 }: {
   config: string
   profile: string
-  payload: AptosFunctionPayload
+  payload: EntryFunctionPayload
   maxGas?: string
 }) {
   const restURL = getRestURL(config, profile)


### PR DESCRIPTION
There were some collisions with public npm packages -- adding a namespace will help avoid that in the future.